### PR TITLE
Added serializers

### DIFF
--- a/cacheables/__init__.py
+++ b/cacheables/__init__.py
@@ -1,1 +1,2 @@
 from cacheables.core import *
+from cacheables.serializers import *

--- a/cacheables/serializers.py
+++ b/cacheables/serializers.py
@@ -1,0 +1,45 @@
+import json
+import pickle
+from pathlib import Path
+from typing import Any
+from abc import ABC, abstractmethod
+
+
+class Serializer(ABC):
+    @abstractmethod
+    def dump(self, path: Path, value: Any):
+        pass
+
+    @abstractmethod
+    def load(self, path: Path):
+        pass
+
+
+class JsonSerializer(Serializer):
+    def _get_path(self, path: Path):
+        return path / "output.json"
+
+    def dump(self, value: Path, path: Any):
+        filepath = self._get_path(path)
+        with open(filepath, "w", encoding="utf-8") as file:
+            json.dump(value, file, indent=4)
+
+    def load(self, path: Path):
+        filepath = self._get_path(path)
+        with open(filepath, "r", encoding="utf-8") as file:
+            return json.load(file)
+
+
+class PickleSerializer(Serializer):
+    def _get_path(self, path: Path):
+        return path / "output.pickle"
+
+    def dump(self, value: Path, path: Any):
+        filepath = self._get_path(path)
+        with open(filepath, "wb") as file:
+            pickle.dump(value, file)
+
+    def load(self, path: Path):
+        filepath = self._get_path(path)
+        with open(filepath, "rb") as file:
+            return pickle.load(file)


### PR DESCRIPTION
Moved from load_fn/dump_fn to Serializers that combine both into a single entity.
You often want to share the same path between load_fn and dump_fn. e.g. `output.pkl`.